### PR TITLE
LessWeb calls TransformToCss explicitly with fileName null.

### DIFF
--- a/src/dotless.Core/Engine/CacheDecorator.cs
+++ b/src/dotless.Core/Engine/CacheDecorator.cs
@@ -28,7 +28,7 @@ namespace dotless.Core
         {
             //Compute Cache Key
             var hash = ComputeContentHash(source);
-            var cacheKey = fileName + hash;
+            var cacheKey = fileName != null ? fileName + hash : hash;
             if (!Cache.Exists(cacheKey))
             {
                 Logger.Debug(String.Format("Inserting cache entry for {0}", cacheKey));


### PR DESCRIPTION
When using LessWeb.Parse, the TransformToCss is explicitly called with fileName = null.
This causes a NullReferenceException when trying to enable caching.